### PR TITLE
[PR] home_navigation

### DIFF
--- a/Quizzly/QuizzlyApp.swift
+++ b/Quizzly/QuizzlyApp.swift
@@ -30,7 +30,7 @@ struct QuizzlyApp: App {
 
     var body: some Scene {
         WindowGroup {
-            CategoryListView()
+            ChooseProfileView()
         }
         .modelContainer(sharedModelContainer)
     }

--- a/Quizzly/VIew/Home/HomeView.swift
+++ b/Quizzly/VIew/Home/HomeView.swift
@@ -9,51 +9,50 @@ import SwiftUI
 
 struct HomeView: View {
     @Bindable var profile: Profile
-
+    @Binding var navigationPath: NavigationPath
+    
     var body: some View {
-        NavigationStack {
-            VStack {
-                HStack {
-                    VStack(alignment: .leading) {
-                        Text("Hi, \(profile.name)")
-                            .font(.title3)
-                            .foregroundStyle(.secondary)
-                        
-                        Text("Find Deals")
-                            .font(.largeTitle)
-                            .bold()
-                    }
+        VStack {
+            HStack {
+                VStack(alignment: .leading) {
+                    Text("Hi, \(profile.name)")
+                        .font(.title3)
+                        .foregroundStyle(.secondary)
                     
-                    Spacer()
-                    
-                    Button {
+                    Text("Find Deals")
+                        .font(.largeTitle)
+                        .bold()
+                }
+                
+                Spacer()
+                
+                Button {
+                    navigationPath = NavigationPath()
+                } label: {
+                    ZStack {
+                        Circle()
+                            .fill(colorFromHex(profile.themeColorHex))
+                            .frame(width: 50, height: 50)
                         
-                    } label: {
-                        ZStack {
-                            Circle()
-                                .fill(colorFromHex(profile.themeColorHex))
-                                .frame(width: 50, height: 50)
-                            
-                            Image(systemName: "person.fill")
-                                .resizable()
-                                .frame(width: 18, height: 18)
-                                .foregroundStyle(.white)
-                        }
+                        Image(systemName: "person.fill")
+                            .resizable()
+                            .frame(width: 18, height: 18)
+                            .foregroundStyle(.white)
                     }
                 }
-                .padding(.top, 50)
-                .padding(.bottom, 15)
             }
-            .padding()
-            .toolbar {
-                ToolbarItem(placement: .topBarLeading) {
-                    Button {
-                        
-                    } label: {
-                        Image("menu")
-                            .resizable()
-                            .frame(width: 23, height: 23)
-                    }
+            .padding(.top, 50)
+            .padding(.bottom, 15)
+        }
+        .padding()
+        .toolbar {
+            ToolbarItem(placement: .topBarLeading) {
+                Button {
+                    
+                } label: {
+                    Image("menu")
+                        .resizable()
+                        .frame(width: 23, height: 23)
                 }
             }
         }
@@ -76,5 +75,5 @@ struct HomeView: View {
 }
 
 #Preview {
-    HomeView(profile: Profile(name: "민지", createdAt: Date.now))
+    HomeView(profile: Profile(name: "민지", createdAt: Date.now), navigationPath: .constant(NavigationPath()))
 }

--- a/Quizzly/VIew/Profile/ChooseProfileView.swift
+++ b/Quizzly/VIew/Profile/ChooseProfileView.swift
@@ -13,21 +13,21 @@ struct ChooseProfileView: View {
     @Query(sort: \Profile.name) private var profiles: [Profile]
     
     @State private var showingAddProfileSheet = false
+    @State private var navigationPath = NavigationPath()
     
     var body: some View {
-        NavigationStack {
+        NavigationStack(path: $navigationPath) {
             VStack {
-                if profiles.isEmpty {
-                    Text("Choose Your Profile")
-                        .font(.largeTitle)
-                } else {
-                    Text("Create Your Profile")
-                        .font(.largeTitle)
-                }
+                let profileDescription: String = profiles.isEmpty ? "Create Your Profile" : "Choose Your Profile"
+                
+                Text(profileDescription)
+                    .font(.largeTitle)
                 
                 HStack(spacing: 20) {
                     ForEach(profiles) { profile in
-                        NavigationLink(destination: HomeView(profile: profile)) {
+                        Button {
+                            navigationPath.append(profile)
+                        } label: {
                             ProfileCardView(profile: profile)
                         }
                     }
@@ -60,6 +60,9 @@ struct ChooseProfileView: View {
             }
             .sheet(isPresented: $showingAddProfileSheet) {
                 AddProfileView()
+            }
+            .navigationDestination(for: Profile.self) { profile in
+                HomeView(profile: profile, navigationPath: $navigationPath)
             }
         }
     }


### PR DESCRIPTION
- 메인화면 category -> chooseProfile 변경
- 내비게이션 navigationPath()추가
- 내비게이션 navigationDestination 함수 chaining

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Update the initial view from `CategoryListView` to `ChooseProfileView` and integrate navigation capabilities by replacing `NavigationStack` with a `NavigationStack(path:)` approach in `HomeView` and `ChooseProfileView`, enabling dynamic path-based navigation.

### Why are these changes being made?

The changes streamline the user experience by presenting the profile selection as the initial view upon app launch, hence guiding users appropriately through their journey. The integration of path-based navigation enhances flexibility and restores the ability to handle complex navigation scenarios, a necessary improvement for forthcoming feature expansions.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->